### PR TITLE
feat: add YAML config loader and sample settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment variables for local development.
+# Copy this file to `.env` and adjust values.
+
+SECRET_KEY=change-me          # Django secret key; replace with a strong random value.
+DEBUG=1                       # 1 to enable debug mode, 0 for production.
+DB_ENGINE=django.db.backends.sqlite3  # Database engine; switch to postgresql for production.
+DB_NAME=db.sqlite3            # Database name or path.
+DB_USER=                      # Database username.
+DB_PASSWORD=                  # Database password.
+DB_HOST=                      # Database host address.
+DB_PORT=                      # Database port number.

--- a/README.md
+++ b/README.md
@@ -109,17 +109,22 @@ La aplicación está diseñada para funcionar como:
    cd duoc-point`
 
 2. Crear archivo `.env` a partir de `.env.example`.
+   Ajusta las variables según tu entorno local (clave secreta, base de datos, etc.).
 
-3. Levantar servicios básicos con Docker:
+3. Revisar los archivos de configuración YAML en `config/` y reemplazar los
+   valores *dummy* según corresponda (dominios, remitentes de correo,
+   parámetros de seguridad, claves de push).
+
+4. Levantar servicios básicos con Docker:
 
    `docker-compose up`
 
-4. Ejecutar migraciones de Django:
+5. Ejecutar migraciones de Django:
 
    `docker-compose exec backend python manage.py migrate`
 
-5. Acceder a la aplicación web en:
+6. Acceder a la aplicación web en:
 
    `http://localhost:8000`
 
-6. En móviles, instalar la aplicación como PWA desde el navegador.
+7. En móviles, instalar la aplicación como PWA desde el navegador.

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -1,0 +1,10 @@
+# app.yaml - Global feature flags and domain settings.
+# Each key defines adjustable behavior for the project.
+features:
+  forum: true            # Enable or disable forum module.
+  schedules: true        # Enable schedules/horarios module.
+  reports: true          # Enable reports module.
+  wellbeing: true        # Enable wellbeing content.
+domains:
+  web: "https://app.example.com"   # Public URL where the web/PWA is served.
+  api: "https://api.example.com"   # Base URL for backend API requests.

--- a/config/email.yaml
+++ b/config/email.yaml
@@ -1,0 +1,7 @@
+# email.yaml - Email senders and template references.
+# Adjust addresses and paths according to deployment.
+default_sender: "no-reply@example.com"  # Global sender email.
+support_sender: "soporte@example.com"  # Support contact address.
+templates:
+  welcome: "emails/welcome.html"        # Path to welcome email template.
+  reset_password: "emails/reset_password.html"  # Path to password reset template.

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,0 +1,14 @@
+# logging.yaml - Logging levels and format configuration.
+# This can be loaded to customize Django logging.
+version: 1  # Standard logging configuration version.
+formatters:
+  simple:
+    format: "[%(levelname)s] %(name)s: %(message)s"  # Basic log line format.
+handlers:
+  console:
+    class: logging.StreamHandler  # Output logs to console.
+    formatter: simple             # Use simple formatter above.
+    level: INFO                   # Minimum level to display.
+root:
+  handlers: [console]             # Apply console handler to root logger.
+  level: INFO                     # Root logger level.

--- a/config/push.yaml
+++ b/config/push.yaml
@@ -1,0 +1,8 @@
+# push.yaml - Web Push and Firebase Cloud Messaging placeholders.
+# Replace dummy values with real keys for production.
+webpush:
+  vapid_public: "PUBLIC_KEY_PLACEHOLDER"   # VAPID public key for Web Push.
+  vapid_private: "PRIVATE_KEY_PLACEHOLDER" # VAPID private key (keep secret).
+  subject: "mailto:soporte@duocpoint.cl"   # Contact email for the push service.
+fcm:
+  server_key: "FCM_SERVER_KEY_PLACEHOLDER" # Firebase server key (optional).

--- a/config/security.yaml
+++ b/config/security.yaml
@@ -1,0 +1,9 @@
+# security.yaml - Rate limits and content policies.
+# Tune these values according to moderation requirements.
+rate_limits:
+  post_create_per_min: 5      # Max posts a user can create per minute.
+  comment_create_per_min: 15  # Max comments a user can create per minute.
+uploads:
+  max_image_size_mb: 5        # Maximum image upload size in megabytes.
+policies:
+  banned_words: ["spam", "scam"]  # Words triggering moderation.

--- a/config/storage.yaml
+++ b/config/storage.yaml
@@ -1,0 +1,7 @@
+# storage.yaml - Storage backend and paths configuration.
+# Adjust to choose where media and static files are stored.
+backend: "local"                 # Storage backend: local, s3, etc.
+local_media_root: "media/"       # Path for user uploads when using local storage.
+s3:
+  bucket_name: "BUCKET_PLACEHOLDER"  # S3 bucket for media files.
+  region: "us-east-1"                # AWS region of the bucket.

--- a/server/duocpoint/settings/base.py
+++ b/server/duocpoint/settings/base.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 import os
 
+# Load YAML configuration using the shared loader. This allows tweaking
+# non-sensitive settings without touching Python code.
+from duocpoint.utils.config_loader import load_config
+
 # base.py está en: server/duocpoint/settings/base.py
 # Queremos que BASE_DIR sea: server/
 BASE_DIR = Path(__file__).resolve().parents[2]
@@ -9,6 +13,13 @@ BASE_DIR = Path(__file__).resolve().parents[2]
 SECRET_KEY = os.getenv("SECRET_KEY", "dev-insecure")
 DEBUG = os.getenv("DEBUG", "1") == "1"
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
+
+# Extra project-level settings loaded from ``config/app.yaml``.  The file
+# contains flags and domain information that might be needed across
+# applications.  When the file or a key is missing, ``load_config`` simply
+# returns an empty dict so the defaults above still apply.
+APP_CONFIG = load_config("app.yaml")
+FEATURE_FLAGS = APP_CONFIG.get("features", {})
 
 # ---- Apps ----
 INSTALLED_APPS = [

--- a/server/duocpoint/utils/__init__.py
+++ b/server/duocpoint/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility helpers for the duocpoint project.
+
+This package groups small modules that provide shared functionality
+outside of any specific Django app. New utilities should live here
+so they can be imported from anywhere in the project.
+"""

--- a/server/duocpoint/utils/config_loader.py
+++ b/server/duocpoint/utils/config_loader.py
@@ -1,0 +1,53 @@
+"""Helpers to load YAML configuration files.
+
+The project keeps non-sensitive configuration in the top-level
+``config/`` directory (feature flags, email senders, push keys, etc.).
+This module exposes :func:`load_config` to read those YAML files and
+return them as Python dictionaries.
+
+Usage:
+    from duocpoint.utils.config_loader import load_config
+    app_cfg = load_config("app.yaml")
+
+Files are cached after the first read to avoid hitting disk multiple
+times within the same process.
+"""
+
+from __future__ import annotations
+
+import yaml
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+# Locate the repository root and the shared ``config`` directory.
+# This file lives at ``server/duocpoint/utils/config_loader.py`` so
+# ``parents[2]`` points to ``server/`` and ``parent`` to the repo root.
+BASE_DIR = Path(__file__).resolve().parents[2]
+CONFIG_DIR = BASE_DIR.parent / "config"
+
+
+@lru_cache(maxsize=None)
+def load_config(name: str) -> Dict[str, Any]:
+    """Return the parsed content of a YAML config file.
+
+    Parameters
+    ----------
+    name:
+        Filename of the YAML file relative to ``config/`` (e.g. ``"app.yaml"``).
+
+    Returns
+    -------
+    dict
+        Dictionary with the parsed content. If the file does not exist or is
+        empty, an empty dict is returned so callers can safely use ``.get``.
+    """
+
+    file_path = CONFIG_DIR / name
+    if not file_path.exists():
+        return {}
+
+    with file_path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    return data

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,6 +7,7 @@ celery>=5.4
 redis>=5.0
 django-storages>=1.14
 boto3>=1.34
+PyYAML>=6.0
 # Opcionales:
 # django-channels>=4.1
 # channels-redis>=4.2


### PR DESCRIPTION
## Summary
- add reusable YAML config loader and expose feature flags
- scaffold example `.env` and config YAML files
- document configuration workflow in README

## Testing
- `pip install -r server/requirements.txt`
- `python manage.py check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b51c9ad87c8331a2cd31c0a6c40e0c