### PR TITLE
Add local start script and dark theme for web

### DIFF
--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r server/requirements.txt
+
+# Apply migrations and run server
+python server/manage.py migrate --noinput
+python server/manage.py runserver 0.0.0.0:8000

--- a/server/duocpoint/urls.py
+++ b/server/duocpoint/urls.py
@@ -15,10 +15,15 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+from django.views.generic import RedirectView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from django.conf import settings
+from django.views.static import serve
+from pathlib import Path
 
 urlpatterns = [
+    path('', RedirectView.as_view(url='/index.html', permanent=False)),
     path('admin/', admin.site.urls),
     path('api/', include('duocpoint.apps.accounts.urls')),
     path('api/', include('duocpoint.apps.campuses.urls')),
@@ -32,4 +37,7 @@ urlpatterns = [
     path('api/', include('duocpoint.apps.portfolio.urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='docs'),
+    re_path(r'^(?P<path>.*)$', serve, {
+        'document_root': Path(settings.BASE_DIR).parent / 'web'
+    }),
 ]

--- a/web/index.html
+++ b/web/index.html
@@ -5,14 +5,21 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="manifest" href="/manifest.webmanifest" />
 <link rel="stylesheet" href="/styles.css" />
-<meta name="theme-color" content="#6a1b9a" />
+<meta name="theme-color" content="#2e004f" />
 <title>Duoc Point</title>
 </head>
 <body>
 <header>
   <h1>Duoc Point</h1>
 </header>
-<div style="padding:1rem;">
+<nav>
+  <ul>
+    <li><a href="/admin/">Administración</a></li>
+    <li><a href="/api/">API</a></li>
+    <li><a href="/horarios/">Horarios</a></li>
+  </ul>
+</nav>
+<div class="content">
   <button id="installBtn" hidden>Instalar app</button>
 </div>
 <script src="/main.js"></script>

--- a/web/manifest.webmanifest
+++ b/web/manifest.webmanifest
@@ -4,8 +4,8 @@
   "start_url": "/index.html",
   "scope": "/",
   "display": "standalone",
-  "theme_color": "#6a1b9a",
-  "background_color": "#f3e5f5",
+  "theme_color": "#2e004f",
+  "background_color": "#1a0033",
   "icons": [
     {
       "src": "/icon-192.png",

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,17 +1,40 @@
 :root{
-  --main-purple:#6a1b9a;
+  --main-purple:#2e004f;
   --gold:#ffd700;
-  --bg:#f3e5f5;
+  --bg-start:#1a0033;
+  --bg-end:#000000;
 }
 body{
   margin:0;
   font-family:Arial, sans-serif;
-  background:var(--bg);
-  color:#1a1a1a;
+  background:linear-gradient(135deg,var(--bg-start),var(--bg-end));
+  color:var(--gold);
 }
 header{
   background:var(--main-purple);
   color:var(--gold);
+  padding:1rem;
+  text-align:center;
+}
+nav{
+  background:rgba(46,0,79,0.8);
+}
+nav ul{
+  list-style:none;
+  margin:0;
+  padding:0.5rem;
+  display:flex;
+  gap:1rem;
+  justify-content:center;
+}
+nav a{
+  color:var(--gold);
+  text-decoration:none;
+}
+nav a:hover{
+  text-decoration:underline;
+}
+.content{
   padding:1rem;
   text-align:center;
 }
@@ -27,5 +50,5 @@ button:hover{
   opacity:0.9;
 }
 a{
-  color:var(--main-purple);
+  color:var(--gold);
 }


### PR DESCRIPTION
## Summary
- add `run_local.sh` to install dependencies and launch Django server
- serve static `web` assets and redirect `/` to the dark-themed index
- refresh landing page styles with gold/purple gradient

## Testing
- `python server/manage.py migrate --noinput`
- `python server/manage.py test`
- `python server/manage.py runserver 0.0.0.0:8000` (manual curl)


------
https://chatgpt.com/codex/tasks/task_e_68b59bb9c6a08331a3f48dd48c992682