### PR TITLE
Add minimal PWA support and base template

### DIFF
--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#0d6efd" />
+  <title>{% block title %}Duoc-Point{% endblock %}</title>
+</head>
+<body>
+  {% block content %}{% endblock %}
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/server/templates/portfolio/basic.html
+++ b/server/templates/portfolio/basic.html
@@ -1,12 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"/></head>
-<body>
+{% extends "base.html" %}
+
+{% block content %}
 <h1>Portafolio de {{ user.name }}</h1>
 <p>Carrera: {{ user.career }}</p>
 <ul>
   <li>Logro destacado 1</li>
   <li>Logro destacado 2</li>
 </ul>
-</body>
-</html>
+{% endblock %}

--- a/web/icons/icon-192.png
+++ b/web/icons/icon-192.png
@@ -1,0 +1,1 @@
+placeholder icon 192x192

--- a/web/icons/icon-512.png
+++ b/web/icons/icon-512.png
@@ -1,0 +1,1 @@
+placeholder icon 512x512

--- a/web/icons/maskable-512.png
+++ b/web/icons/maskable-512.png
@@ -1,0 +1,1 @@
+placeholder maskable icon 512x512

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="manifest" href="/manifest.webmanifest" />
 <link rel="stylesheet" href="/styles.css" />
-<meta name="theme-color" content="#2e004f" />
+<meta name="theme-color" content="#0d6efd" />
 <title>Duoc Point</title>
 </head>
 <body>

--- a/web/manifest.webmanifest
+++ b/web/manifest.webmanifest
@@ -1,23 +1,14 @@
 {
-  "name": "Duoc Point",
-  "short_name": "DuocPt",
-  "start_url": "/index.html",
+  "name": "Duoc-Point",
+  "short_name": "DuocPoint",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "theme_color": "#2e004f",
-  "background_color": "#1a0033",
+  "background_color": "#ffffff",
+  "theme_color": "#0d6efd",
   "icons": [
-    {
-      "src": "/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any maskable"
-    }
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable any" }
   ]
 }

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,35 +1,30 @@
-const CACHE_NAME = 'static-cache-v1';
-const STATIC_ASSETS = [
-  '/index.html',
-  '/main.js',
-  '/manifest.webmanifest'
-];
+const CACHE = "duocpoint-v1";
+const ASSETS = ["/", "/styles.css", "/main.js", "/manifest.webmanifest"]; // agrega lo que necesites
 
-self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS)));
+self.addEventListener("install", (e) => {
+  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(ASSETS)));
 });
 
-self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') {
-    return;
-  }
-  const url = new URL(event.request.url);
-  if (STATIC_ASSETS.includes(url.pathname)) {
-    event.respondWith(caches.match(event.request));
-    return;
-  }
-  event.respondWith(
-    fetch(event.request)
-      .then(resp => {
-        const clone = resp.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
-        return resp;
-      })
-      .catch(() => caches.match(event.request))
+self.addEventListener("activate", (e) => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    )
   );
 });
 
-self.addEventListener('push', (event) => {
-  const data = event.data?.json() || {title: 'Notificación', body: ''};
-  event.waitUntil(self.registration.showNotification(data.title, {body: data.body}));
+self.addEventListener("fetch", (e) => {
+  e.respondWith(
+    fetch(e.request).then(res => {
+      const copy = res.clone();
+      caches.open(CACHE).then(c => c.put(e.request, copy));
+      return res;
+    }).catch(() => caches.match(e.request))
+  );
+});
+
+// (opcional) handler para push
+self.addEventListener("push", (e) => {
+  const data = e.data?.json() || { title: "Duoc-Point", body: "Notificación" };
+  e.waitUntil(self.registration.showNotification(data.title, { body: data.body }));
 });


### PR DESCRIPTION
## Summary
- add Django base template with manifest, theme color and service worker registration
- introduce PWA manifest and service worker with simple caching strategy
- include placeholder icons and align index theme color

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68bb8cf61e5c8331b02ff5f921aa4635